### PR TITLE
Split responsibilities in AdminMiddleware

### DIFF
--- a/app/Core/Middleware/DefaultErrorHandler.php
+++ b/app/Core/Middleware/DefaultErrorHandler.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Core\Middleware;
+
+class DefaultErrorHandler implements ErrorHandlerInterface
+{
+  public function handleForbidden(): void
+  {
+    http_response_code(403);
+    echo "403 Forbidden — у вас немає доступу";
+    exit;
+  }
+}

--- a/app/Core/Middleware/ErrorHandlerInterface.php
+++ b/app/Core/Middleware/ErrorHandlerInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Core\Middleware;
+
+interface ErrorHandlerInterface
+{
+  public function handleForbidden(): void;
+}


### PR DESCRIPTION
Усунення "запаху коду"

Проблема: Клас AdminMiddleware порушує Принцип єдиної відповідальності (SRP), оскільки:

- Перевіряє права доступу.

- Безпосередньо виводить HTTP-відповідь 403.

Запах: "Mixed Responsibilities" (поєднання логіки перевірок та виводу).

Рішення: Застосування шаблону "Strategy" для виводу помилок через інтерфейс ErrorHandlerInterface.

Переваги:

- Можливість легко змінити формат відповіді (наприклад, JSON замість HTML).

- Спрощує тестування (мок обробника помилок).

Чекліст:

1) Додано ErrorHandlerInterface.

2) Реалізовано DefaultErrorHandler.

3) Оновлено AdminMiddleware.